### PR TITLE
Improve Api Connections

### DIFF
--- a/src/Nylas.php
+++ b/src/Nylas.php
@@ -74,6 +74,7 @@ class Nylas
 
         return new Client([
             'base_uri' => $this->apiServer,
+            'connect_timeout' => 60,
             'timeout' => 150,
             'handler' => $handlerStack
         ]);
@@ -106,7 +107,7 @@ class Nylas
     private function retryDelay()
     {
         return function($numberOfRetries) {
-            return 2000 * $numberOfRetries;
+            return 60 * $numberOfRetries;
         };
     }
 


### PR DESCRIPTION
 - Add 'connect_timeout' in Guzzle Client
 - Change retry times from 2000 to 60